### PR TITLE
cleanup, ACL respect in

### DIFF
--- a/Controller/RestApi.php
+++ b/Controller/RestApi.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace DataGroupApi\Controller;
+
+class RestApi extends \LimeExtra\Controller {
+
+    protected function before() {
+        $this->app->response->mime = 'json';
+    }
+
+    public function get($dataGroupName) {
+        $current_user = $this->module('cockpit')->getUser(); // this MAY be null if no valid token is provided to the API be the callee
+
+        $allCollections = $this->module("collections")->collections();
+        $allSingletons = $this->module("singletons")->singletons();
+
+        // TODO: i'm not sure what this is supposed to be and if its necessary
+        $options = [];
+        if ($lang = $this->param("lang", false)) $options["lang"] = $lang;
+        $options["populate"] = true;
+        if ($ignoreDefaultFallback = $this->param("ignoreDefaultFallback", false)) $options["ignoreDefaultFallback"] = $ignoreDefaultFallback;
+        if ($current_user) $options["user"] = $current_user;
+
+        /*
+         * gather both singletons+collections data
+         */
+        $singletons = [];
+        foreach($allSingletons as $singletonName => $singletonSchema) {
+            $allowed_through_token = $this->module('singletons')->hasaccess($singletonName, 'data');
+            $allowed_through_public = $singletonSchema && ($singletonSchema['acl']['public']['data']??false)===true;
+
+            if($singletonSchema['group'] === $dataGroupName && ($allowed_through_token || $allowed_through_public))
+                $singletons[] = $this->module("singletons")->getData($singletonName, $options);
+        }
+        $collections = [];
+        foreach($allCollections as $collectionName => $collectionSchema) {
+            $allowed_through_token = $this->module('collections')->hasaccess($collectionName, 'entries_view');
+            $allowed_through_public = $collectionSchema && ($collectionSchema['acl']['public']['entries_view']??false)===true;
+
+            if($collectionSchema['group'] === $dataGroupName && ($allowed_through_token || $allowed_through_public))
+                $collections[] = $this->module("collections")->find($collectionName, $options);
+        }
+
+        return json_encode(compact('singletons', 'collections'));
+    }
+
+}

--- a/README.md
+++ b/README.md
@@ -1,11 +1,8 @@
-# cockpitCms-groupapi
-Provides a group API for cockpit CMS
+# CockpitCMS-DataGroupApi
+Provides an API for getting all singleton data + collection entries that are determined withunder a passed group's name
 
+**Provides the following API-Endpoint:**
 
-Provides the following URL:
+/api/datagroup/:groupName
 
-/api/grp/:group
-
-The Api it returns is currently public - so use at your own discretion. 
-
-PR's welcome
+Singleton data and collection entries are returned according to their actual ACLs while public access is also preved and respected for the request.


### PR DESCRIPTION
- the addon now follows the "cockpit coding convention" - code is now written the way it is within the cockpit core modules (consider it a minor cleanup)
- **NEW:** the addon now respects ACLs for the singletons and collections within a group. So calling the API endpoint won't expose data anymore that neither has public- nor token-access (of course the token must be correct if one is needed and provided)